### PR TITLE
Add support for multiple ACL entry per principal

### DIFF
--- a/Carbon/Functions/Grant-Permission.ps1
+++ b/Carbon/Functions/Grant-Permission.ps1
@@ -355,7 +355,7 @@ function Grant-Permission
         $setAccessRule = ($Force -or $missingPermission)
         if( $setAccessRule )
         {
-            $currentAcl.SetAccessRule( $accessRule )
+            $currentAcl.AddAccessRule( $accessRule )
         }
 
         if( $rulesToRemove -or $setAccessRule )


### PR DESCRIPTION
This PR change the behavior of Grant-Permission function according to issue #37.
It permits to have multiple ACL entry for each principal.

---

I don't know if #37 behavior is by design. However, It can cause some issues in the use case already [reported](https://github.com/pshdo/Carbon/issues/37#issue-278197210) by @bozho .

In the code, at [this line](https://github.com/pshdo/Carbon/blob/9f128f869798e05cab79abd339c781fa94ee52c3/Carbon/Functions/Grant-Permission.ps1#L358), the ACL edit is performed by the `SetAccessRule` method of `FileSystemSecurity` class.

In [this commit](https://github.com/pshdo/Carbon/pull/38/commits/4ff6238bd8a850c0adc395d21093e2beba805121)  I use the `FileSystemSecurity.AddAccessRule` Method ([ref](https://msdn.microsoft.com/en-us/library/d49cww7f(v=vs.110).aspx)) to add rules  insted of replace it.