### PR TITLE
Bugfix/windows 10 firewall service

### DIFF
--- a/Carbon/Functions/Assert-FirewallConfigurable.ps1
+++ b/Carbon/Functions/Assert-FirewallConfigurable.ps1
@@ -35,11 +35,15 @@ function Assert-FirewallConfigurable
 
     Use-CallerPreference -Cmdlet $PSCmdlet -Session $ExecutionContext.SessionState
 
-    if( (Get-Service -Name 'MpsSvc').Status -ne 'Running' )
+    if( (Get-Service -DisplayName 'Windows Firewall' -ErrorAction Ignore).Status -eq 'Running' )
     {
-        Write-Error "Unable to configure firewall: Windows Firewall service isn't running."
-        return $false
+        return $true
     }
-    return $true
-}
+    elseif( (Get-Service -Name 'MpsSvc').Status -eq 'Running' )
+    {
+        return $true
+    }
 
+    Write-Error "Unable to configure firewall: Windows Firewall service isn't running."
+    return $false
+}

--- a/Carbon/Functions/Assert-FirewallConfigurable.ps1
+++ b/Carbon/Functions/Assert-FirewallConfigurable.ps1
@@ -35,7 +35,7 @@ function Assert-FirewallConfigurable
 
     Use-CallerPreference -Cmdlet $PSCmdlet -Session $ExecutionContext.SessionState
 
-    if( (Get-Service 'Windows Firewall').Status -ne 'Running' ) 
+    if( (Get-Service -Name 'MpsSvc').Status -ne 'Running' )
     {
         Write-Error "Unable to configure firewall: Windows Firewall service isn't running."
         return $false

--- a/Carbon/Functions/Assert-FirewallConfigurable.ps1
+++ b/Carbon/Functions/Assert-FirewallConfigurable.ps1
@@ -35,7 +35,7 @@ function Assert-FirewallConfigurable
 
     Use-CallerPreference -Cmdlet $PSCmdlet -Session $ExecutionContext.SessionState
 
-    if( (Get-Service -DisplayName 'Windows Firewall' -ErrorAction Ignore).Status -eq 'Running' )
+    if( (Get-Service 'Windows Firewall' -ErrorAction Ignore).Status -eq 'Running' )
     {
         return $true
     }

--- a/RELEASE NOTES.txt
+++ b/RELEASE NOTES.txt
@@ -1,3 +1,9 @@
+# 2.5.1
+
+## Bug Fixes
+
+ * Fixed: `Assert-FirewallConfigurable` fails on Windows 10 due to firewall service display name change.
+
 # 2.5.0 (18 June 2017)
 
 ## Enhancements

--- a/Source/Test/IO/ReparsePointTestFixture.cs
+++ b/Source/Test/IO/ReparsePointTestFixture.cs
@@ -24,7 +24,7 @@ namespace Carbon.Test.IO
         [Test]
         public void ShouldGetTargetPathForJunction()
         {
-            var path = IOPath.Combine(Environment.GetEnvironmentVariable("TEMP"), IOPath.GetRandomFileName());
+            var path = IOPath.Combine(IOPath.GetTempPath(), IOPath.GetRandomFileName());
             Directory.CreateDirectory(path);
             var junctionPath = string.Format("{0}+junction", path);
             JunctionPoint.Create(junctionPath, path, true);


### PR DESCRIPTION
- Fixed: Assert-FirewallConfigurable fails on Windows 10 due to firewall service name change.
- Fixed: ReparsePointTestFixture test was broken due to using TEMP environment variable which contains a shortened tilde path.