### PR TITLE
bugfix/windows 10 firewall service

### DIFF
--- a/Carbon/Functions/Assert-FirewallConfigurable.ps1
+++ b/Carbon/Functions/Assert-FirewallConfigurable.ps1
@@ -35,7 +35,7 @@ function Assert-FirewallConfigurable
 
     Use-CallerPreference -Cmdlet $PSCmdlet -Session $ExecutionContext.SessionState
 
-    if( (Get-Service 'Windows Firewall' -ErrorAction Ignore).Status -eq 'Running' )
+    if( (Get-Service 'Windows Firewall' -ErrorAction Ignore | Select-Object -ExpandProperty 'Status' -ErrorAction Ignore) -eq 'Running' )
     {
         return $true
     }


### PR DESCRIPTION
Assert-FirewallConfigurable should not write an error if the Status property cannot be found on the old firewall service name